### PR TITLE
Add --base-url flag for connector testability

### DIFF
--- a/cmd/baton-oracle-ebs/main.go
+++ b/cmd/baton-oracle-ebs/main.go
@@ -50,6 +50,7 @@ func getConnector(ctx context.Context, c *cfg.OracleEbs) (types.ConnectorServer,
 		Server:   c.Server,
 		Service:  c.Service,
 		Port:     c.Port,
+		BaseURL:  c.BaseUrl,
 	}
 
 	cb, err := connector.New(ctx, ebsCfg)

--- a/pkg/config/conf.gen.go
+++ b/pkg/config/conf.gen.go
@@ -9,6 +9,7 @@ type OracleEbs struct {
 	Server string `mapstructure:"server"`
 	Service string `mapstructure:"service"`
 	Port int `mapstructure:"port"`
+	BaseUrl string `mapstructure:"base-url"`
 }
 
 func (c *OracleEbs) findFieldByTag(tagValue string) (any, bool) {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -33,12 +33,18 @@ var (
 		field.WithDescription("Port for the Oracle EBS connection"),
 	)
 
+	BaseURLField = field.StringField(
+		"base-url",
+		field.WithDescription("Override the Oracle EBS connection URL (for testing)"),
+	)
+
 	ConfigurationFields = []field.SchemaField{
 		UsernameField,
 		PasswordField,
 		ServerField,
 		ServiceField,
 		PortField,
+		BaseURLField,
 	}
 
 	ConfigurationSchema = field.Configuration{

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -36,6 +36,7 @@ var (
 	BaseURLField = field.StringField(
 		"base-url",
 		field.WithDescription("Override the Oracle EBS connection URL (for testing)"),
+		field.WithHidden(true),
 	)
 
 	ConfigurationFields = []field.SchemaField{

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -37,6 +37,7 @@ var (
 		"base-url",
 		field.WithDescription("Override the Oracle EBS connection URL (for testing)"),
 		field.WithHidden(true),
+		field.WithExportTarget(field.ExportTargetCLIOnly),
 	)
 
 	ConfigurationFields = []field.SchemaField{

--- a/pkg/connector/connector.go
+++ b/pkg/connector/connector.go
@@ -67,7 +67,10 @@ const (
 func New(ctx context.Context, cfg ebs.Config) (*OracleEBS, error) {
 	var connString string
 
-	// Use base-url if provided (for testing), otherwise build from components
+	// Use base-url if provided (for testing), otherwise build from components.
+	// When base-url is set, credentials must be embedded in the connection
+	// string or handled by the test harness — this intentionally bypasses
+	// the username/password config fields.
 	if cfg.BaseURL != "" {
 		connString = cfg.BaseURL
 	} else {

--- a/pkg/connector/connector.go
+++ b/pkg/connector/connector.go
@@ -65,35 +65,42 @@ const (
 
 // New returns a new instance of the connector.
 func New(ctx context.Context, cfg ebs.Config) (*OracleEBS, error) {
-	var port int
-	var server, service string
+	var connString string
 
-	if cfg.Port == 0 {
-		port = DefaultPort
+	// Use base-url if provided (for testing), otherwise build from components
+	if cfg.BaseURL != "" {
+		connString = cfg.BaseURL
 	} else {
-		port = cfg.Port
-	}
+		var port int
+		var server, service string
 
-	if cfg.Server == "" {
-		server = DefaultServer
-	} else {
-		server = cfg.Server
-	}
+		if cfg.Port == 0 {
+			port = DefaultPort
+		} else {
+			port = cfg.Port
+		}
 
-	if cfg.Service == "" {
-		service = DefaultService
-	} else {
-		service = cfg.Service
-	}
+		if cfg.Server == "" {
+			server = DefaultServer
+		} else {
+			server = cfg.Server
+		}
 
-	connString := ora.BuildUrl(
-		server,
-		port,
-		service,
-		cfg.Username,
-		cfg.Password,
-		nil, // TODO: add trace file for debugging?
-	)
+		if cfg.Service == "" {
+			service = DefaultService
+		} else {
+			service = cfg.Service
+		}
+
+		connString = ora.BuildUrl(
+			server,
+			port,
+			service,
+			cfg.Username,
+			cfg.Password,
+			nil, // TODO: add trace file for debugging?
+		)
+	}
 
 	conn, err := ora.NewConnection(connString)
 	if err != nil {

--- a/pkg/ebs/models.go
+++ b/pkg/ebs/models.go
@@ -49,4 +49,6 @@ type Config struct {
 
 	Username string `mapstructure:"username"`
 	Password string `mapstructure:"password"`
+
+	BaseURL string `mapstructure:"base-url"`
 }


### PR DESCRIPTION
## Summary

Adds the `--base-url` CLI flag to enable overriding the default API endpoint for testing purposes.

## Changes

- Added `BaseURLField` to configuration
- Updated client/connector to accept and use the base URL override
- When `--base-url` is provided, it takes precedence over the default API URL

## Files Modified

```
cmd/baton-oracle-ebs/main.go,pkg/config/conf.gen.go,pkg/config/config.go,pkg/connector/connector.go,pkg/ebs/models.go
```

## Testing

The connector can now be tested against mock servers:
```bash
baton-oracle-ebs --base-url http://localhost:8080 [other-flags]
```

## Related

Part of the Connector Testability initiative.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Oracle EBS configuration now includes a new optional connection URL override setting. This allows you to directly specify the complete connection string, providing greater flexibility for testing with different configurations and accommodating various deployment scenarios without requiring separate configuration of individual server, port, and service parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->